### PR TITLE
Do not sort segments in read-format internally

### DIFF
--- a/BarcodeCorrector.hpp
+++ b/BarcodeCorrector.hpp
@@ -123,7 +123,7 @@ public:
 		char buffer[256] ;
 		while (barcodeFile.Next())
 		{	
-			strcpy(buffer, readFormatter.Extract(barcodeFile.seq, FORMAT_BARCODE, true));
+			strcpy(buffer, readFormatter.Extract(barcodeFile.seq, FORMAT_BARCODE, true, true));
 			barcodeFreq.SearchAndUpdate(buffer, 1) ;
 			readCnt += 1 ;
 			if (readCnt >= caseCnt) 

--- a/FastqExtractor.cpp
+++ b/FastqExtractor.cpp
@@ -134,10 +134,10 @@ int IsGoodCandidate( char *read, char *buffer, SeqSet *refSet )
 void OutputSeq( FILE *fp, const char *name, char *seq, char *qual, ReadFormatter &readFormatter, int readCategory )
 {
 	if ( qual != NULL )
-		fprintf( fp, "@%s\n%s\n+\n%s\n", name, readFormatter.Extract(seq, readCategory, true, 0),
+		fprintf( fp, "@%s\n%s\n+\n%s\n", name, readFormatter.Extract(seq, readCategory, true, true, 0),
 				readFormatter.Extract(qual, readCategory, false, 1)) ;
 	else
-		fprintf( fp, ">%s\n%s\n", name, readFormatter.Extract(seq, readCategory, true, 0) ) ;
+		fprintf( fp, ">%s\n%s\n", name, readFormatter.Extract(seq, readCategory, true, true, 0) ) ;
 }
 
 // Maybe barcode read quality could be useful in future.
@@ -147,7 +147,7 @@ void OutputBarcode( FILE *fp, const char *name, char *barcode, char *qual,
 {
 	if (barcode && barcode[0] != '\0')
 	{
-		char *bcBuffer = readFormatter.Extract(barcode, readCategory, true, 0) ;
+		char *bcBuffer = readFormatter.Extract(barcode, readCategory, true, true, 0) ;
 		int result = 0 ;
 		if ( barcodeCorrector != NULL )	
 			result = barcodeCorrector->Correct(bcBuffer, qual ) ;


### PR DESCRIPTION
So user scan control the segment order. Also allowing negative number to indicate the distance to the read end, instead of only allow -1.