### PR TITLE
changed mkdir to make_path

### DIFF
--- a/run-trust4
+++ b/run-trust4
@@ -6,6 +6,7 @@ use warnings ;
 use Cwd 'cwd' ;
 use Cwd 'abs_path' ;
 use File::Basename ;
+use File::Path qw(make_path);
 
 die "TRUST4 v1.0.14-r488 usage: ./run-trust4 [OPTIONS]:\n".
     "Required:\n".
@@ -363,7 +364,7 @@ if ( $prefix eq "" )
 
 if ( $outputDirectory ne "" )
 {
-	mkdir $outputDirectory if ( !-d $outputDirectory ) ;
+	make_path($outputDirectory) if ( !-d $outputDirectory ) ;
 	$prefix = "$outputDirectory/$prefix" ;
 }
 


### PR DESCRIPTION
Thanks for the great codebase. A minor issue that recently came up: the code was failing with error message "failed: 139 at {my_path}/TRUST4/run-trust4 line 55". In the end, it turned out that this was due to me specifying an out directory with --od that didn't exist. This led to an error with the mkdir command: https://github.com/liulab-dfci/TRUST4/blob/183fb6f985ba5a9b00c7769eeac1b8d5e8adf606/run-trust4#L366 . Modified to use make_path. Thanks again!