### PR TITLE
Fix an issue of regarding IGLLx, like IGLL1, as a constant gene from recent IMGT reference sequences

### DIFF
--- a/BarcodeTranslator.hpp
+++ b/BarcodeTranslator.hpp
@@ -67,9 +67,10 @@ class BarcodeTranslator {
 			khiter_t barcode_translate_table_iter =
           kh_get(barcodeHash, barcode_translate_table_, bc_from.c_str());
       if (barcode_translate_table_iter == kh_end(barcode_translate_table_)) {
-        std::cerr << "Barcode " << bc_from << " does not exist in the translation table."
-                  << std::endl;
-        exit(-1);
+        //std::cerr << "Barcode " << bc_from << " does not exist in the translation table."
+        //          << std::endl;
+        //exit(-1);
+        return ret; // ret should be empty
       }
       std::string bc_to(
           kh_value(barcode_translate_table_, barcode_translate_table_iter));

--- a/SeqSet.hpp
+++ b/SeqSet.hpp
@@ -4622,13 +4622,19 @@ public:
 		switch ( name[3] )
 		{
 			case 'V': geneType = 0 ; break ;
-			case 'D': 
+			case 'D':
 				  if ( name[4] >= '0' && name[4] <= '9' )
 					  geneType = 1 ; 
 				  else
 					  geneType = 3 ;
 				  break ;
 			case 'J': geneType = 2 ; break ;
+			case 'L': 
+					if (GetChainType(name) == 2)
+					{
+						geneType = -1 ; // IGLL genes
+						break ;
+					}
 			default: geneType = 3 ; break ;
 		}
 		return geneType ;
@@ -5687,7 +5693,7 @@ public:
 			for (i = 0 ; i < overlapCnt ; ++i)
 			{
 				int geneType = GetGeneType( seqs[ overlaps[i].seqIdx ].name ) ;
-				if (geneCompared[geneType] == 1)
+				if (geneType < 0 || geneCompared[geneType] == 1)
 					continue ;
 
 				if (geneUsed[geneType] == -1)
@@ -5708,9 +5714,9 @@ public:
 
 		for ( i = 0 ; i < overlapCnt ; ++i )
 		{
-			// Remove the hits on the D gene
+			// Remove the hits on the D gene or other random genes (genetype==-1)
 			int geneType = GetGeneType( seqs[ overlaps[i].seqIdx ].name ) ;
-			if ( geneType == 1 )
+			if ( geneType < 0 || geneType == 1 )
 				continue ;
 
 			// Remove those overlaps that was secondary as well.

--- a/run-trust4
+++ b/run-trust4
@@ -7,7 +7,7 @@ use Cwd qw(cwd abs_path) ;
 use File::Basename ;
 use File::Path qw(make_path) ;
 
-my $version = "v1.1.4-r527" ;
+my $version = "v1.1.4-r530" ;
 
 die "TRUST4 $version usage: ./run-trust4 [OPTIONS]:\n".
     "Required:\n".

--- a/run-trust4
+++ b/run-trust4
@@ -7,7 +7,7 @@ use Cwd qw(cwd abs_path) ;
 use File::Basename ;
 use File::Path qw(make_path) ;
 
-my $version = "v1.1.3-r526" ;
+my $version = "v1.1.4-r527" ;
 
 die "TRUST4 $version usage: ./run-trust4 [OPTIONS]:\n".
     "Required:\n".


### PR DESCRIPTION
Also add an option --skipBarcodeErrorRead for fastq-extractor. This option is for customized script, and is not exposed in the run-trust4 wrapper.