### PR TITLE
Improve running efficiency when --barcode option is given

### DIFF
--- a/FastqExtractor.cpp
+++ b/FastqExtractor.cpp
@@ -207,6 +207,14 @@ void *ProcessReads_Thread( void *pArg )
 		if ( !goodCandidate && arg.readBatch2 && IsGoodCandidate( arg.readBatch2[i].seq, arg.buffer, arg.refSet ) )
 			++goodCandidate ;
 
+		if (goodCandidate && arg.barcodeBatch)
+		{
+			if ((!strcmp(arg.barcodeBatch[i].seq, arg.readBatch[i].seq)
+						|| (arg.readBatch2 && !strcmp(arg.barcodeBatch[i].seq, arg.readBatch2[i].seq))) 
+					&& IsLowComplexity(arg.barcodeBatch[i].seq))
+				goodCandidate = 0 ;
+		}
+
 		if ( !goodCandidate ) 
 			arg.readBatch[i].id[0] = '\0' ;
 		/*else if (arg.barcodeBatch != NULL)
@@ -499,6 +507,15 @@ int main( int argc, char *argv[] )
 				++goodCandidate ;
 			if ( !goodCandidate && hasMate && IsGoodCandidate( mateReads.seq, seqBuffer, &refSet ) )
 				++goodCandidate ;
+			
+			if (goodCandidate && hasBarcode)
+			{
+				if ((!strcmp(barcodeFile.seq, reads.seq)
+						|| (hasMate && !strcmp(barcodeFile.seq, mateReads.seq)) ) 
+						&& IsLowComplexity(barcodeFile.seq) )
+					goodCandidate = 0 ;
+			}
+
 			if ( goodCandidate )
 			{
 				int barcodeNoError = 1 ;

--- a/KmerCode.hpp
+++ b/KmerCode.hpp
@@ -17,17 +17,21 @@ class KmerCode
 		}
 		KmerCode( int kl ) 
 		{
-			int i ;
 			kmerLength = kl ;
 			code = 0 ;
 			invalidPos = -1 ;
 
-			mask = 0 ;
+			/*mask = 0 ;
+			int i ;
 			for ( i = 0 ; i < kmerLength ; ++i )
 			{
 				mask = mask << 2 ;
 				mask = mask | 3 ;
-			}
+			}*/
+			if (kmerLength < 32)
+				mask = (1ull << (uint64_t)(2*kmerLength)) - 1ull ;
+			else
+				mask = (uint64_t)(-1) ;
 		}
 
 		KmerCode( const KmerCode& in )

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ TRUST4 is also available form [Bioconda](https://anaconda.org/bioconda/trust4). 
 			--UMI STRING: if -b, bam field for 10x Genomics-like UMI; if -1 -2/-u, file containing 10x Genomics-like UMIs (default: not used)
 			--readFormat STRING: format for read, barcode and UMI files (example: r1:0:-1,r2:0:-1,bc:0:15,um:16:-1 for paired-end files with barcode and UMI)
 			--repseq: the data is from bulk,non-UMI-based TCR-seq or BCR-seq (default: not set)
+			--contigMinCov INT: ignore contigs that have bases covered by fewer than INT reads (default: 0)
 			--minHitLen INT: the minimal hit length for a valid overlap (default: auto)
 			--mateIdSuffixLen INT: the suffix length in read id for mate. (default: not used)
 			--skipMateExtension: do not extend assemblies with mate information, useful for SMART-seq (default: not used)

--- a/SeqSet.hpp
+++ b/SeqSet.hpp
@@ -4474,6 +4474,8 @@ public:
 				
 				// Update posweight
 				ns.posWeight.SetZero( 0, newConsensusLen ) ;
+				ns.numRead = 0 ;
+				ns.index = true ;
 				for ( j = 0 ; j < k ; ++j )
 				{
 					int l ;
@@ -8514,7 +8516,7 @@ public:
 		delete[] buffer ;
 	}
 	
-	
+	// Not used now.
 	void BreakFalseAssembly( std::vector<struct _Read> reads )
 	{
 		int i, j, k ;
@@ -8641,12 +8643,16 @@ public:
 				ns.consensusLen = end - start + 1 ;
 				ns.name = strdup( seqs[i].name ) ;
 				ns.isRef = false ;
+				ns.numRead = 0 ;
+				ns.index = true ;
 				
 				ns.posWeight.Reserve( end - start + 1 ) ;
 				int l ;
 				for ( l = start ; l <= end ; ++l )
+				{
 					ns.posWeight.PushBack( seqs[i].posWeight[l] ) ;	
-
+					ns.numRead += seqs[i].numRead ;
+				}
 				seqs.push_back( ns ) ;
 				//printf( "Break %d to %d.\n", i, seqs.size() - 1 ) ;
 			}
@@ -10003,12 +10009,15 @@ public:
 			ns.name = strdup( seqs[i].name ) ;
 			ns.posWeight.ExpandTo( newConsensusLen ) ;
 			ns.posWeight.SetZero( 0, newConsensusLen ) ;
+			ns.numRead = 0 ;
+			ns.index = true ;
 
 			// Assign the posWeight of the core part.	
 			int newSeqIdx = seqs.size() ;
 			for ( j = 0 ; j < chainSize ; ++j )
 			{
 				int l ;
+				ns.numRead += seqs[chain[j]].numRead ;
 				for ( l = range[j].a ; l <= origRangeB[j] && offset[j] + l - range[j].a < newConsensusLen ; ++l )
 				{
 					ns.posWeight[ offset[j] + l - range[j].a ] += seqs[ chain[j] ].posWeight[l] ;
@@ -10257,6 +10266,8 @@ public:
 		std::sort( seqs.begin(), seqs.end() ) ; 
 	}
 
+	// USE THIS FUNCTION WITH CAUTION. 
+	// After calling this function, the scaffolding function will break.
 	// The sequences with those barcode will not be updated and used
 	// Release the position weight array for the sequences from the specified barcodes
 	//   if their coverage is even
@@ -10284,7 +10295,7 @@ public:
 			}
 			UpdateConsensus(i, false) ;
 			struct _seqWrapper &seq = seqs[i] ;
-
+			
 			if (removeFromIndex)
 			{
 				seq.index = false ;

--- a/SeqSet.hpp
+++ b/SeqSet.hpp
@@ -10322,6 +10322,29 @@ public:
 		}
 	}
 
+	// Release contigs with bases with too few read coverage
+	void ReleaseShallowContigs(int minCov)
+	{
+		int i, j ;
+		int size = seqs.size() ;
+		for (i = 0 ; i < size ; ++i)
+		{
+			struct _seqWrapper &seq = seqs[i] ;
+			int len = seq.consensusLen ;
+			if (seq.isRef || seq.consensus == NULL)
+				continue ;
+
+			for (j = 0 ; j < len ; ++j)
+			{
+				if (seq.posWeight[j].Sum() < minCov)
+					break ;
+			}
+
+			if (j < len)
+				ReleaseSeq(i) ;
+		}
+	}
+
 	void Output( FILE *fp, std::vector<std::string> *barcodeIntToStr = NULL )
 	{
 		int i, j, k ;

--- a/SeqSet.hpp
+++ b/SeqSet.hpp
@@ -29,6 +29,8 @@ struct _seqWrapper
 	struct _triple info[3] ; // For storing extra information. for ref, info[0,1] contains the coordinate for CDR1,2 and info[2].a for CDR3
 					// In extending seqs with mate pair information, these are used to store rough V, J, C read coordinate.	
 	int barcode ; // transformed barcode. -1: no barcode
+	int numRead ; // number of read assigned to the seq. TODO: need to check whether this is accuracy
+	bool index ; // whether this sequence will be added to the index.
 
 	bool operator<( const struct _seqWrapper &b )	const
 	{
@@ -2435,6 +2437,8 @@ public:
 			}
 			ns.name = strdup( fa.id ) ;
 			ns.isRef = true ;
+			ns.numRead = 0 ;
+			ns.index = true ;
 
 			int id = seqs.size() ;
 			seqs.push_back( ns ) ;
@@ -2704,6 +2708,8 @@ public:
 		
 		sw.barcode = -1 ;
 		sw.minLeftExtAnchor = sw.minRightExtAnchor = 0 ;
+		sw.numRead = 0 ;
+		sw.index = true ;
 		SetPrevAddInfo( seqIdx, 0, seqLen - 1, 0, seqLen - 1, 1 ) ;
 		return seqIdx ;
 	}	
@@ -2724,6 +2730,8 @@ public:
 		ns.consensusLen = seqLen ;	
 		ns.minLeftExtAnchor = ns.minRightExtAnchor = 0 ;
 		ns.barcode = barcode ;
+		ns.numRead = 1 ;
+		ns.index = true ;
 		for (i = 0 ; i < 3 ; ++i)
 		{
 			struct _triple nt ;
@@ -2764,6 +2772,8 @@ public:
 		ns.consensusLen = seqLen ;	
 		ns.barcode = -1 ;	
 		ns.minLeftExtAnchor = ns.minRightExtAnchor = 0 ;
+		ns.numRead = 0 ;
+		ns.index = true ; 
 		for (int i = 0 ; i < 3 ; ++i)
 		{
 			struct _triple nt ;
@@ -2806,7 +2816,10 @@ public:
 			ns.posWeight = in.seqs[i].posWeight ;
 			ns.minLeftExtAnchor = in.seqs[i].minLeftExtAnchor ;
 			ns.minRightExtAnchor = in.seqs[i].minRightExtAnchor ;
-			seqIndex.BuildIndexFromRead( kmerCode, ns.consensus, ns.consensusLen, id, ns.barcode) ;
+			ns.numRead = in.seqs[i].numRead ;
+			ns.index = in.seqs[i].index ;
+			if (ns.index)
+				seqIndex.BuildIndexFromRead( kmerCode, ns.consensus, ns.consensusLen, id, ns.barcode) ;
 			seqs.push_back( ns ) ;
 		}
 	}
@@ -3995,6 +4008,8 @@ public:
 			}
 			//printf( "%d %s %lld\n", ns.posWeight.Size(), ns.consensus, ns.posWeight.BeginAddress() ) ;
 			ns.minLeftExtAnchor = ns.minRightExtAnchor = 0 ;
+			ns.numRead = 1 ;
+			ns.index = true ;
 			seqs.push_back( ns ) ;
 
 			// Don't forget to update index.
@@ -4049,6 +4064,7 @@ public:
 				continue ;
 			++seq.posWeight[i + prevAddInfo.seqStart].count[ nucToNum[ r[i] - 'A' ] ] ;
 		}
+		++seq.numRead ;
 
 		if ( prevAddInfo.strand == -1 )
 			free( r ) ;
@@ -4067,6 +4083,7 @@ public:
 			ReverseComplement( r, read, len ) ;
 		
 		UpdatePosWeightFromRead( seqs[ assign.seqIdx ].posWeight, assign.seqStart, r ) ;
+		++seqs[assign.seqIdx].numRead ;
 		free( r ) ;
 	}
 	
@@ -4088,6 +4105,9 @@ public:
 		int i, j ;
 		struct _seqWrapper &seq = seqs[ seqIdx ] ;
 		SimpleVector<struct _pair> changes ;
+		if (seq.posWeight.Size() == 0)
+			return ;
+
 		for ( i = 0 ; i < seq.consensusLen ; ++i )
 		{
 			int max = 0 ;
@@ -4112,7 +4132,7 @@ public:
 			}
 		}
 
-		if ( changes.Size() == 0 )
+		if ( changes.Size() == 0 || seqs[seqIdx].index == false)
 			return ;
 		
 		if ( updateIndex )
@@ -4159,7 +4179,8 @@ public:
 			seqs[k] = seqs[i] ;
 			//if ( i != k )
 			//	seqIndex.UpdateIndexFromRead( kmerCode, seqs[k].consensus, seqs[k].consensusLen, 0, i, k ) ;
-			seqIndex.BuildIndexFromRead( kmerCode, seqs[k].consensus, seqs[k].consensusLen, k, seqs[k].barcode, 0 ) ;
+			if (seqs[k].index)
+				seqIndex.BuildIndexFromRead( kmerCode, seqs[k].consensus, seqs[k].consensusLen, k, seqs[k].barcode, 0 ) ;
 			++k ;
 		}
 		SetPrevAddInfo( -1, -1, -1, -1, -1, 0 ) ; 
@@ -4460,8 +4481,9 @@ public:
 					int seqIdx = path[j] ;
 					for ( l = 0 ; l < seqs[ seqIdx ].consensusLen ; ++l )
 						ns.posWeight[l + seqOffset[j] ] += seqs[ seqIdx ].posWeight[l] ; 
+					ns.numRead += seqs[seqIdx].numRead ;
 				} 
-				// Update name
+				// Update name 
 				int sum = 0 ;
 				for ( j = 0 ; j < k ; ++j )
 					sum += strlen( seqs[ path[j] ].name ) ;
@@ -10236,6 +10258,61 @@ public:
 		std::sort( seqs.begin(), seqs.end() ) ; 
 	}
 
+	// Release the position weight array for the sequences from the specified barcodes
+	//   if their coverage is even
+	void ReleaseEvenCoverageBarcodeSeqPosWeight(std::map<int, int> barcodes, bool removeFromIndex)
+	{
+		int size = seqs.size() ;
+		int len ;
+		int i, j, k;
+		KmerCode kmerCode( kmerLength ) ;
+
+		for (i = 0 ; i < size ; ++i)
+		{
+			if (barcodes.find(seqs[i].barcode) == barcodes.end())
+				continue ;
+			
+			UpdateConsensus(i, false) ;
+			struct _seqWrapper &seq = seqs[i] ;
+			len = seq.consensusLen ;
+			int cov = 0 ;
+			for (j = 0 ; j < len ; ++j)	
+			{
+				for (k = 0 ; k < 4 ; ++k)
+				{
+					if (k == nucToNum[seq.consensus[j] - 'A'])
+					{
+						if (seq.posWeight[j].count[k] == 0) // unfixable 'N', because we update the consensus before
+							break ;
+
+						if (j == 0)
+							cov = seq.posWeight[j].count[k] ;
+						else if (seq.posWeight[j].count[k] != cov)
+							break ;
+					}
+					else if (seq.posWeight[j].count[k] != 0)
+						break ;
+				}
+
+				if (k < 4)
+					break ;
+			}
+
+			if (j < len) // Coverage is not even
+				continue ;
+
+			// This sequence has even coverage
+			seq.numRead = cov ;
+			seq.posWeight.Release() ;
+			
+			if (removeFromIndex)
+			{
+				seq.index = false ;
+				seqIndex.RemoveIndexFromRead( kmerCode, seq.consensus, seq.consensusLen, i, seq.barcode, 0 ) ;
+			}
+		}
+	}
+
 	void Output( FILE *fp, std::vector<std::string> *barcodeIntToStr = NULL )
 	{
 		int i, j, k ;
@@ -10251,11 +10328,28 @@ public:
 				fprintf( fp, ">%s_%d %s\n%s\n", barcodeIntToStr->at( seqs[i].barcode ).c_str(), i, seqs[i].name, 
 							seqs[i].consensus ) ;
 			
-			for ( k = 0 ; k < 4 ; ++k )
+			if (seqs[i].posWeight.Size() > 0)
 			{
-				for ( j = 0 ; j < seqs[i].consensusLen ; ++j )
-					fprintf( fp, "%d ", seqs[i].posWeight[j].count[k] ) ;
-				fprintf( fp, "\n" ) ;
+				for ( k = 0 ; k < 4 ; ++k )
+				{
+					for ( j = 0 ; j < seqs[i].consensusLen ; ++j )
+						fprintf( fp, "%d ", seqs[i].posWeight[j].count[k] ) ;
+					fprintf( fp, "\n" ) ;
+				}
+			}
+			else
+			{
+				for (k = 0 ; k < 4 ; ++k)
+				{
+					for ( j = 0 ; j < seqs[i].consensusLen ; ++j )
+					{
+						if (nucToNum[seqs[i].consensus[j] - 'A'] == k)
+							fprintf( fp, "%d ", seqs[i].numRead ) ;
+						else
+							fprintf( fp, "0 ") ;
+					}
+					fprintf( fp, "\n" ) ;
+				}
 			}
 		}
 	}
@@ -10342,7 +10436,7 @@ public:
 
 		seq.consensus[pos] = c ;
 
-		if (updateIndex)
+		if (updateIndex && seq.index)
 			seqIndex.BuildIndexFromRead(kmerCode, seq.consensus + start, end - start + 1, seqIdx, seq.barcode, start) ;
 	}
 	

--- a/main.cpp
+++ b/main.cpp
@@ -1633,14 +1633,14 @@ int main( int argc, char *argv[] )
 			} // end if for setting good candidate
 			
 			// Check whether the many barcode is already finished, so we can purge them from the index and posWeight array
-			if (0 && hasBarcode && !keepMissingBarcode && sortedReads[i].barcode != -1)
+			if (hasBarcode && !keepMissingBarcode && sortedReads[i].barcode != -1)
 			{
 				int barcode = sortedReads[i].barcode ;
 				++barcodeReadCount[barcode] ;
 				if (barcodeReadCount[barcode] >= barcodeTotalReadCount[barcode])
 				{
 					finishedBarcodes[barcode] = barcodeTotalReadCount[barcode] ;
-					if (finishedBarcodes.size() >= 10000) // clean up the memory once every 10000 barcode finishes. The sort makes sure the barocde is processed one by one, so it can be efficiently removed.
+					if (finishedBarcodes.size() >= 1) // clean up the memory once every barcode finishes. The sort makes sure the barocde is processed one by one, so it can be efficiently removed.
 					{
 						seqSet.ReleaseFinishedBarcodeSeq(finishedBarcodes, /*release_index*/true, /*early_stop*/true) ;
 						finishedBarcodes.clear() ;

--- a/main.cpp
+++ b/main.cpp
@@ -31,9 +31,9 @@ char usage[] = "./trust4 [OPTIONS]:\n"
 		///"\t--noV: do not assemble the full length V gene (default: not used)\n"
 		"\t--trimLevel INT: 0: no trim; 1: trim low quality; 2: trim unmatched (default: 1)\n"
 		"\t--barcode STRING: the path to the barcode file (default: not used)\n"
-		"\t--contigMinCov INT: ignore contigs that have bases covered by fewer than INT reads (default: 0)\n"
 		"\t--UMI STRING: the path to the UMI file (default: not used)\n"
-		"\t--keepNoBarcode: assemble the reads with missing barcodes. (default: ignore the reads)\n" ;
+		"\t--keepNoBarcode: assemble the reads with missing barcodes. (default: ignore the reads)\n" 
+		"\t--contigMinCov INT: ignore contigs that have bases covered by fewer than INT reads (default: 0)\n" ;
 
 int nucToNum[26] = { 0, -1, 1, -1, -1, -1, 2, 
 	-1, -1, -1, -1, -1, -1, 0,

--- a/main.cpp
+++ b/main.cpp
@@ -31,7 +31,7 @@ char usage[] = "./trust4 [OPTIONS]:\n"
 		///"\t--noV: do not assemble the full length V gene (default: not used)\n"
 		"\t--trimLevel INT: 0: no trim; 1: trim low quality; 2: trim unmatched (default: 1)\n"
 		"\t--barcode STRING: the path to the barcode file (default: not used)\n"
-		"\t--barcodeMinRead INT: ignore barcodes with less than INT reads (default: 0)\n"
+		"\t--contigMinCov INT: ignore contigs that have bases covered by fewer than INT reads (default: 0)\n"
 		"\t--UMI STRING: the path to the UMI file (default: not used)\n"
 		"\t--keepNoBarcode: assemble the reads with missing barcodes. (default: ignore the reads)\n" ;
 
@@ -53,7 +53,7 @@ static struct option long_options[] = {
 			{ "UMI", required_argument, 0, 10004},
 			{ "skipMateExtension", no_argument, 0, 10005},
 			{ "minHitLen", required_argument, 0, 10006},
-			{ "barcodeMinRead", required_argument, 0, 10007},
+			{ "contigMinCov", required_argument, 0, 10007},
 			{ (char *)0, 0, 0, 0} 
 			} ;
 
@@ -322,7 +322,7 @@ int main( int argc, char *argv[] )
 	bool keepMissingBarcode = false ;
 	int threadCnt = 1 ;
 	bool skipMateExtension = false ;
-	int barcodeMinRead = 0 ;
+	int contigMinCov = 0 ;
 
 	while ( 1 )
 	{
@@ -401,7 +401,7 @@ int main( int argc, char *argv[] )
 		}
 		else if ( c == 10007 )
 		{
-			barcodeMinRead = atoi( optarg ) ;
+			contigMinCov = atoi( optarg ) ;
 		}
 		else
 		{
@@ -474,7 +474,7 @@ int main( int argc, char *argv[] )
 				barcodeIntToStr.push_back( s ) ;
 			}
 
-			if (barcodeMinRead > 0)
+			if (contigMinCov > 0)
 			{
 				if (barcode >= barcodeTotalReadCount.Size())
 					barcodeTotalReadCount.PushBack(1) ;
@@ -773,11 +773,11 @@ int main( int argc, char *argv[] )
 	int readCnt = sortedReads.size() ;
 
 	// Remove the reads from the barcode with too few reads
-	if (barcodeMinRead > 0)
+	if (contigMinCov > 0)
 	{
 		for (i = 0 ; i < readCnt ; ++i)
 		{
-			if (sortedReads[i].barcode != -1 && barcodeTotalReadCount[sortedReads[i].barcode] < barcodeMinRead)
+			if (sortedReads[i].barcode != -1 && barcodeTotalReadCount[sortedReads[i].barcode] < contigMinCov)
 			{
 				free( sortedReads[i].read ) ;
 				free( sortedReads[i].id ) ;
@@ -1737,6 +1737,11 @@ int main( int argc, char *argv[] )
 	fprintf( stderr, "Annotate the contigs.\n" ) ;
 	seqSet.Annotate( refSet ) ;*/
 
+	if (contigMinCov > 0)
+	{
+		seqSet.ReleaseShallowContigs(contigMinCov) ;
+	}
+	
 	// Output the preliminary assembly.
 	//seqSet.Clean( true ) ;
 	FILE *fp ;

--- a/main.cpp
+++ b/main.cpp
@@ -1301,6 +1301,7 @@ int main( int argc, char *argv[] )
 	{
 		barcodeTotalReadCount.Reserve(barcodeIntToStr.size()) ;
 		barcodeReadCount.Reserve(barcodeIntToStr.size()) ;
+		barcodeTotalReadCount.SetZero(0, barcodeIntToStr.size()) ;
 		barcodeReadCount.SetZero(0, barcodeIntToStr.size()) ;
 		for (i = 0 ; i < readCnt ; ++i)
 		{
@@ -1569,20 +1570,20 @@ int main( int argc, char *argv[] )
 					goodCandidate[ sortedReads[i].mateIdx ] = good ;
 					sortedReads[ sortedReads[i].mateIdx ].info = i;
 				}
-
-				// Check whether the many barcode is already finished, so we can purge them from the index and posWeight array
-				if (hasBarcode && sortedReads[i].barcode != -1)
+			} // end if for setting good candidate
+			
+			// Check whether the many barcode is already finished, so we can purge them from the index and posWeight array
+			if (hasBarcode && !keepMissingBarcode && sortedReads[i].barcode != -1)
+			{
+				int barcode = sortedReads[i].barcode ;
+				++barcodeReadCount[barcode] ;
+				if (barcodeReadCount[barcode] >= barcodeTotalReadCount[barcode])
 				{
-					int barcode = sortedReads[i].barcode ;
-					++barcodeReadCount[barcode] ;
-					if (barcodeReadCount[barcode] >= barcodeTotalReadCount[barcode])
+					finishedBarcodes[barcode] = barcodeTotalReadCount[barcode] ;
+					if (finishedBarcodes.size() >= 500000) // clean up the memory once every 500K barcode finishes
 					{
-						finishedBarcodes[barcode] = barcodeTotalReadCount[barcode] ;
-						if (finishedBarcodes.size() >= 1000000)
-						{
-							seqSet.ReleaseEvenCoverageBarcodeSeqPosWeight(finishedBarcodes, true) ;
-							finishedBarcodes.clear() ;
-						}
+						seqSet.ReleaseEvenCoverageBarcodeSeqPosWeight(finishedBarcodes, true) ;
+						finishedBarcodes.clear() ;
 					}
 				}
 			}

--- a/run-trust4
+++ b/run-trust4
@@ -28,13 +28,13 @@ die "TRUST4 $version usage: ./run-trust4 [OPTIONS]:\n".
 		#"\t--barcodeRange INT INT CHAR: start, end(-1 for length-1), strand in a barcode is the true barcode (default: 0 -1 +)\n".
     "\t--barcodeWhitelist STRING: path to the barcode whitelist (default: not used)\n".
 		"\t--barcodeTranslate STRING: path to the barcode translate file (default: not used)\n".
-		"\t--contigMinCov INT: ignore contigs that have bases covered by fewer than INT reads (default: 0)\n".
 		#"\t--read1Range INT INT: start, end(-1 for length-1) in -1/-u files for genomic sequence (default: 0 -1)\n".
 		#"\t--read2Range INT INT: start, end(-1 for length-1) in -2 files for genomic sequence (default: 0 -1)\n".
 		"\t--UMI STRING: if -b, bam field for 10x Genomics-like UMI; if -1 -2/-u, file containing 10x Genomics-like UMIs (default: not used)\n".
 		#"\t--umiRange INT INT CHAR: start, end(-1 for lenght-1), strand in a UMI is the true UMI (default: 0 -1 +)\n".
 		"\t--readFormat STRING: format for read, barcode and UMI files (example: r1:0:-1,r2:0:-1,bc:0:15,um:16:-1 for paired-end files with barcode and UMI)\n".
     "\t--repseq: the data is from bulk,non-UMI-based TCR-seq or BCR-seq (default: not set)\n".
+		"\t--contigMinCov INT: ignore contigs that have bases covered by fewer than INT reads (default: 0)\n".
 		"\t--minHitLen INT: the minimal hit length for a valid overlap (default: auto)\n".
     "\t--mateIdSuffixLen INT: the suffix length in read id for mate. (default: not used)\n".
     "\t--skipMateExtension: do not extend assemblies with mate information, useful for SMART-seq (default: not used)\n".

--- a/run-trust4
+++ b/run-trust4
@@ -7,7 +7,7 @@ use Cwd qw(cwd abs_path) ;
 use File::Basename ;
 use File::Path qw(make_path) ;
 
-my $version = "v1.1.4-r534" ;
+my $version = "v1.1.5-r536" ;
 
 die "TRUST4 $version usage: ./run-trust4 [OPTIONS]:\n".
     "Required:\n".
@@ -28,6 +28,7 @@ die "TRUST4 $version usage: ./run-trust4 [OPTIONS]:\n".
 		#"\t--barcodeRange INT INT CHAR: start, end(-1 for length-1), strand in a barcode is the true barcode (default: 0 -1 +)\n".
     "\t--barcodeWhitelist STRING: path to the barcode whitelist (default: not used)\n".
 		"\t--barcodeTranslate STRING: path to the barcode translate file (default: not used)\n".
+		"\t--contigMinRead INT: filter contig with less than specified number of reads (default: 0)\n".
 		#"\t--read1Range INT INT: start, end(-1 for length-1) in -1/-u files for genomic sequence (default: 0 -1)\n".
 		#"\t--read2Range INT INT: start, end(-1 for length-1) in -2 files for genomic sequence (default: 0 -1)\n".
 		"\t--UMI STRING: if -b, bam field for 10x Genomics-like UMI; if -1 -2/-u, file containing 10x Genomics-like UMIs (default: not used)\n".
@@ -228,6 +229,11 @@ for ( $i = 0 ; $i < @ARGV ; ++$i )
 	elsif ( $ARGV[$i] eq "--barcodeTranslate" )
 	{
 		$fastqExtractorArgs .= " --barcodeTranslate ".$ARGV[$i + 1] ;
+		$i += 1 ;
+	}
+	elsif ( $ARGV[$i] eq "--barcodeMinRead")
+	{
+		$mainArgs .= " --barcodeMinRead ".$ARGV[$i + 1] ;
 		$i += 1 ;
 	}
 	elsif ( $ARGV[$i] eq "--UMI" )

--- a/run-trust4
+++ b/run-trust4
@@ -28,7 +28,7 @@ die "TRUST4 $version usage: ./run-trust4 [OPTIONS]:\n".
 		#"\t--barcodeRange INT INT CHAR: start, end(-1 for length-1), strand in a barcode is the true barcode (default: 0 -1 +)\n".
     "\t--barcodeWhitelist STRING: path to the barcode whitelist (default: not used)\n".
 		"\t--barcodeTranslate STRING: path to the barcode translate file (default: not used)\n".
-		"\t--contigMinRead INT: filter contig with less than specified number of reads (default: 0)\n".
+		"\t--contigMinCov INT: ignore contigs that have bases covered by fewer than INT reads (default: 0)\n".
 		#"\t--read1Range INT INT: start, end(-1 for length-1) in -1/-u files for genomic sequence (default: 0 -1)\n".
 		#"\t--read2Range INT INT: start, end(-1 for length-1) in -2 files for genomic sequence (default: 0 -1)\n".
 		"\t--UMI STRING: if -b, bam field for 10x Genomics-like UMI; if -1 -2/-u, file containing 10x Genomics-like UMIs (default: not used)\n".
@@ -231,9 +231,9 @@ for ( $i = 0 ; $i < @ARGV ; ++$i )
 		$fastqExtractorArgs .= " --barcodeTranslate ".$ARGV[$i + 1] ;
 		$i += 1 ;
 	}
-	elsif ( $ARGV[$i] eq "--barcodeMinRead")
+	elsif ( $ARGV[$i] eq "--contigMinCov")
 	{
-		$mainArgs .= " --barcodeMinRead ".$ARGV[$i + 1] ;
+		$mainArgs .= " --contigMinCov ".$ARGV[$i + 1] ;
 		$i += 1 ;
 	}
 	elsif ( $ARGV[$i] eq "--UMI" )


### PR DESCRIPTION
- Remove the candidate read if the barcode is from a low-complexity read
- Also add a parameter "--contigMinCov" that can prefilter barcode with too few reads and filter contigs that has a "dip" of coverage in the middle.