### PR TITLE
Improving the computational efficiency for barcode-based data 

### DIFF
--- a/Annotator.cpp
+++ b/Annotator.cpp
@@ -749,7 +749,7 @@ int main( int argc, char *argv[] )
 		int strand, minCnt, medCnt ;
 		k = 0 ;
 		PrintLog( "Start to realign reads for CDR3 analysis." ) ;
-		seqSet.Clean( false ) ;
+		seqSet.Clean( false ) ; // This will force create the index
 
 		std::vector<struct _assignRead> cdr3Reads ; // Keep the information of the reads aligned to cdr3 region.
 		std::vector<struct _assignRead> assembledReads ;

--- a/KmerCount.hpp
+++ b/KmerCount.hpp
@@ -157,7 +157,6 @@ public:
 			return 0 ;
 	}
 
-
 	int GetCountStatsAndTrim( char *read, char *qual, int &minCount, int &medianCount, float &avgCount )
 	{
 		int i, k ;
@@ -259,6 +258,13 @@ public:
 
 		return 1 ;
 	}
+
+  void Clear()
+  {
+    int i ;
+    for (i = 0 ; i < khashMax ; ++i)
+      count[i].clear() ;
+  }
 
 	void Release()
 	{

--- a/KmerIndex.hpp
+++ b/KmerIndex.hpp
@@ -95,6 +95,8 @@ public:
 		{
 			//printf( "remove %d %d\n", idx, offset ) ;
 			list.Remove( i ) ;
+			if (list.Size() == 0 && barcode != -1)
+				index[ GetHash(kmerCode.GetCode(), barcode) ].erase(kmerCode.GetCode()) ;
 		}
 	}
 	
@@ -176,7 +178,6 @@ public:
 			//for ( j = 0 ; j < size ; ++j )
 			//	printf( "test %d %d\n", list[j].idx, list[j].offset ) ;
 		}
-
 	}
 
 	void RemoveIndexFromRead( KmerCode &kmerCode, char *s, int len, int id, int barcode, int offset )
@@ -197,6 +198,23 @@ public:
 				Remove( kmerCode, id, i - kl + 1 + offset, 1, barcode ) ;
 			}
 		}
+	}
+
+	size_t GetSpace()
+	{
+		int i ;
+		size_t ret = 0 ;
+		ret += sizeof(*index) * KINDEX_HASH_MAX + sizeof(*this) ;
+		for (i = 0 ; i < KINDEX_HASH_MAX ; ++i)
+		{
+			ret += index[i].size() * (sizeof(int64_t) + sizeof(SimpleVector<struct _indexInfo>)) ;
+			for (std::map<uint64_t, SimpleVector<struct _indexInfo> >::iterator iter = index[i].begin() ;
+					iter != index[i].end() ; ++iter)
+			{
+				ret += iter->second.GetSpace() ;
+			}
+		}
+		return ret ;
 	}
 } ;
 

--- a/SeqSet.hpp
+++ b/SeqSet.hpp
@@ -4217,10 +4217,10 @@ public:
 			}
 		}
 
-		if ( changes.Size() == 0 || seqs[seqIdx].index == false)
+		if ( changes.Size() == 0 ) //|| seqs[seqIdx].index == false)
 			return ;
 		
-		if ( updateIndex )
+		if ( updateIndex && seqs[seqIdx].index)
 		{
 			// Inefficient implementation, improve in future.
 			KmerCode kmerCode( kmerLength ) ;
@@ -4231,7 +4231,7 @@ public:
 		for ( i = 0 ; i < size ; ++i )
 			seq.consensus[ changes[i].a ] = numToNuc[ changes[i].b ] ;
 
-		if ( updateIndex )
+		if ( updateIndex && seqs[seqIdx].index)
 		{
 			KmerCode kmerCode( kmerLength ) ;
 			seqIndex.BuildIndexFromRead( kmerCode, seq.consensus, seq.consensusLen, seqIdx, seq.barcode, 0 ) ;

--- a/SeqSet.hpp
+++ b/SeqSet.hpp
@@ -10603,6 +10603,21 @@ public:
 		}
 		delete[] buffer ;
 	}
+
+	size_t GetSpace()
+	{
+		int i ;
+		size_t ret = seqIndex.GetSpace() ;
+		int seqCnt = seqs.size() ;
+		for (i = 0 ; i < seqCnt ; ++i)
+		{
+			ret += sizeof(seqs[i]) ;
+			ret += sizeof(char) * strlen(seqs[i].name) ;
+			ret += sizeof(char) * seqs[i].consensusLen ;
+			ret += seqs[i].posWeight.GetSpace() ;
+		}
+		return ret ;
+	}
 } ;
 
 

--- a/SeqSet.hpp
+++ b/SeqSet.hpp
@@ -3764,7 +3764,7 @@ public:
 				seqs[ newSeqIdx ].consensusLen = newConsensusLen ;
 				
 				// Update the index
-				UpdateConsensus( newSeqIdx, false ) ;
+				UpdateConsensus( newSeqIdx, false ) ; 
 				seqIndex.BuildIndexFromRead( kmerCode, newConsensus, newConsensusLen, newSeqIdx, barcode ) ;
 				
 				// Update the anchor requirement.

--- a/SimpleVector.hpp
+++ b/SimpleVector.hpp
@@ -105,7 +105,11 @@ public:
 		if ( maxInc > 0 && inc > maxInc )
 			inc = maxInc ;
 	}
-
+  
+	size_t GetSpace()
+	{
+		return sizeof(T) * capacity ;
+	}
 
 	int PushBack( const T &in )	
 	{

--- a/main.cpp
+++ b/main.cpp
@@ -985,7 +985,6 @@ int main( int argc, char *argv[] )
 		}
 		PrintLog( "Finish re-sorting the reads based on barcode." ) ;
 	}
-
 	/*for (i = 0 ; i < readCnt ; ++i)
 	{
 		int germlineMatchCnt = 0 ;
@@ -1672,6 +1671,7 @@ int main( int argc, char *argv[] )
 		}
 	}
 	seqSet.UpdateAllConsensus() ;
+	//printf("index=%lu reads=%lu\n", seqSet.GetSpace(), sortedReads.size() * sizeof(sortedReads[0])) ;
 	PrintLog(  "Assembled %d reads.", assembledReadCnt ) ;
 
 	// Go through the second round.
@@ -1745,7 +1745,7 @@ int main( int argc, char *argv[] )
 	{
 		seqSet.ReleaseShallowContigs(contigMinCov) ;
 	}
-	
+
 	// Output the preliminary assembly.
 	//seqSet.Clean( true ) ;
 	FILE *fp ;

--- a/main.cpp
+++ b/main.cpp
@@ -108,10 +108,6 @@ struct _sortRead
 			return avgCnt > b.avgCnt ;
 		else if ( len != b.len )
 			return len > b.len ;
-    if (barcode != -1 && barcode != b.barcode)
-			return barcode < b.barcode ;
-		else if ( barcode != -1 && b.barcode != -1 && barcodeMinCnt != b.barcodeMinCnt )
-			return barcodeMinCnt > b.barcodeMinCnt ;
 		//else if (avgQual != b.avgQual)
 		//	return avgQual > b.avgQual ;
 		//else if (germlineMatchCnt != b.germlineMatchCnt)
@@ -131,8 +127,8 @@ bool CompReadWithBarcode(const struct _sortRead &a, const struct _sortRead &b)
 {
 	if (a.barcode != -1 && a.barcode != b.barcode)
 		return a.barcode < b.barcode ;
-  else if (a.barcode == -1 && b.barcode != -1)
-		return false ;
+	else if ( a.barcode != -1 && b.barcode != -1 && a.barcodeMinCnt != b.barcodeMinCnt )
+		return a.barcodeMinCnt > b.barcodeMinCnt ;
   else
     return a < b ;
 }
@@ -939,9 +935,11 @@ int main( int argc, char *argv[] )
 					barcodeKmerCount.AddCount(sortedReads[k].read) ;
 
 				for (k = i ; k < j ; ++k)
+				{
 					barcodeKmerCount.GetCountStatsAndTrim(sortedReads[k].read, NULL,
 							sortedReads[k].barcodeMinCnt, sortedReads[k].barcodeMedianCnt,
 							sortedReads[k].barcodeAvgCnt ) ;  
+				}
 
 				barcodeKmerCount.Clear() ;
 				i = j ;

--- a/main.cpp
+++ b/main.cpp
@@ -1652,7 +1652,8 @@ int main( int argc, char *argv[] )
 			}
 		}
 
-		if ( assembledReadCnt > 0 && assembledReadCnt % 10000 == 0 )
+		if ( assembledReadCnt > 0 && assembledReadCnt % 10000 == 0 
+				&& !hasBarcode)
 			seqSet.UpdateAllConsensus() ;
 
 		if ( ( i + 1 ) % 100000 == 0 )

--- a/run-trust4
+++ b/run-trust4
@@ -38,6 +38,7 @@ die "TRUST4 $version usage: ./run-trust4 [OPTIONS]:\n".
 		"\t--minHitLen INT: the minimal hit length for a valid overlap (default: auto)\n".
     "\t--mateIdSuffixLen INT: the suffix length in read id for mate. (default: not used)\n".
     "\t--skipMateExtension: do not extend assemblies with mate information, useful for SMART-seq (default: not used)\n".
+		"\t--skipReadRealign: do not realign reads in annotator, useful for reducing computation cost of barcode/UMI-based repseq (default: not used)\n".
     "\t--abnormalUnmapFlag: the flag in BAM for the unmapped read-pair is nonconcordant (default: not set)\n".
     "\t--noExtraction: directly use the files from provided -1 -2/-u to assemble (default: extraction first)\n".
     "\t--imgtAdditionalGap STRING: description for additional gap codon position in IMGT (0-based), e.g. \"TRAV:7,83\" for mouse (default: no)\n".
@@ -99,6 +100,7 @@ my $outputReadAssignment = 0 ;
 my $chainsInBarcode = 2 ;
 my $assembleWithRef = 0 ;
 my $cleanup = 0 ;
+my $skipReadRealign = 0 ;
 
 print STDERR "[".localtime()."] TRUST4 $version begins.\n" ;
 for ( $i = 0 ; $i < @ARGV ; ++$i )
@@ -285,6 +287,10 @@ for ( $i = 0 ; $i < @ARGV ; ++$i )
 	elsif ( $ARGV[$i] eq "--repseq" )
 	{
 		$mainArgs .= " --trimLevel 2 --skipMateExtension" ;
+	}
+	elsif ( $ARGV[$i] eq "--skipReadRealign")
+	{
+		$skipReadRealign = 1 ;
 	}
 	elsif ($ARGV[$i] eq "--barcode-level" || $ARGV[$i] eq "--barcodeLevel")
 	{
@@ -499,9 +505,9 @@ if ( $stage <= 1 )
 # Annotation 
 if ( $stage <= 2 )
 {
-	if (1) #$hasBarcode == 0 || $hasUmi == 1)
+	if ( $skipReadRealign == 0) #$hasBarcode == 0 || $hasUmi == 1)
 	{
-    # Always use the read now. For consistent and reproducible abundance estimation if user want to examine read assignment.
+    # Always use the read now if otherwise instructed. For consistent and reproducible abundance estimation if user want to examine read assignment.
 		$annotatorArgs .= " -r ${prefix}_assembled_reads.fa" ;
 	}
 	else


### PR DESCRIPTION
- Add the option "--skipReadAlign" to avoid the computational intensive read realignment step in annotator. This maybe useful in some very deeply sequenced repseq data.