### PR TITLE
Fix an issue of initializing read format in fastq-extractor when using --barcodeStart/End

### DIFF
--- a/ReadFormatter.hpp
+++ b/ReadFormatter.hpp
@@ -233,6 +233,7 @@ public:
     ns.start = start ;
     ns.end = end ;
     ns.strand = strand ;
+    ns.inComment = false ;
     _segs[category].push_back(ns) ;
     //std::sort(_segs[ category ].begin(), _segs[ category ].end()) ;
     

--- a/run-trust4
+++ b/run-trust4
@@ -7,7 +7,7 @@ use Cwd qw(cwd abs_path) ;
 use File::Basename ;
 use File::Path qw(make_path) ;
 
-my $version = "v1.1.10-r631" ;
+my $version = "v1.1.10-r633" ;
 
 die "TRUST4 $version usage: ./run-trust4 [OPTIONS]:\n".
     "Required:\n".


### PR DESCRIPTION
- Fix #404 